### PR TITLE
Add consultant profiles and editable consultant records

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+email-validator

--- a/src/README.md
+++ b/src/README.md
@@ -9,7 +9,8 @@ A FastAPI application that enables Slalom consultants to register their capabili
 ## Features
 
 - View all available consulting capabilities
-- Register consultant expertise and availability
+- Create and update consultant profiles
+- Register consultant expertise and availability using consultant records
 - Track skill levels and certifications
 - Manage capability capacity and team assignments
 
@@ -18,7 +19,7 @@ A FastAPI application that enables Slalom consultants to register their capabili
 1. Install the dependencies:
 
    ```
-   pip install fastapi uvicorn
+   pip install -r ../requirements.txt
    ```
 
 2. Run the application:
@@ -37,6 +38,10 @@ A FastAPI application that enables Slalom consultants to register their capabili
 | Method | Endpoint                                                          | Description                                                         |
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/capabilities`                                                   | Get all capabilities with details and current consultant assignments |
+| GET    | `/consultants`                                                    | List consultant profiles                                             |
+| GET    | `/consultants/{email}`                                            | Retrieve a consultant profile                                        |
+| POST   | `/consultants`                                                    | Create a consultant profile                                          |
+| PUT    | `/consultants/{email}`                                            | Update a consultant profile                                          |
 | POST   | `/capabilities/{capability_name}/register?email=consultant@slalom.com` | Register consultant for a capability                     |
 | DELETE | `/capabilities/{capability_name}/unregister?email=consultant@slalom.com` | Unregister consultant from a capability              |
 
@@ -57,9 +62,11 @@ The application uses a consulting-focused data model:
 2. **Consultants** - Uses email as identifier:
    - Name
    - Practice area
-   - Skill level
-   - Certifications
-   - Availability
+   - Location
+   - Bio / summary
+   - Optional contact details
+
+Capability registrations now point to consultant records instead of storing raw email strings in the UI workflow.
 
 All data is currently stored in memory for this learning exercise. In a production environment, this would be backed by a robust database system.
 

--- a/src/app.py
+++ b/src/app.py
@@ -5,9 +5,13 @@ A FastAPI application that enables Slalom consultants to register their
 capabilities and manage consulting expertise across the organization.
 """
 
+from copy import deepcopy
+from typing import Dict, List, Optional
+
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from pydantic import BaseModel, EmailStr
 import os
 from pathlib import Path
 
@@ -27,8 +31,8 @@ capabilities = {
         "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
         "certifications": ["AWS Solutions Architect", "Azure Architect Expert"],
         "industry_verticals": ["Healthcare", "Financial Services", "Retail"],
-        "capacity": 40,  # hours per week available across team
-        "consultants": ["alice.smith@slalom.com", "bob.johnson@slalom.com"]
+        "capacity": 40,
+        "consultant_emails": ["alice.smith@slalom.com", "bob.johnson@slalom.com"]
     },
     "Data Analytics": {
         "description": "Advanced data analysis, visualization, and machine learning solutions",
@@ -37,7 +41,7 @@ capabilities = {
         "certifications": ["Tableau Desktop Specialist", "Power BI Expert", "Google Analytics"],
         "industry_verticals": ["Retail", "Healthcare", "Manufacturing"],
         "capacity": 35,
-        "consultants": ["emma.davis@slalom.com", "sophia.wilson@slalom.com"]
+        "consultant_emails": ["emma.davis@slalom.com", "sophia.wilson@slalom.com"]
     },
     "DevOps Engineering": {
         "description": "CI/CD pipeline design, infrastructure automation, and containerization",
@@ -46,7 +50,7 @@ capabilities = {
         "certifications": ["Docker Certified Associate", "Kubernetes Admin", "Jenkins Certified"],
         "industry_verticals": ["Technology", "Financial Services"],
         "capacity": 30,
-        "consultants": ["john.brown@slalom.com", "olivia.taylor@slalom.com"]
+        "consultant_emails": ["john.brown@slalom.com", "olivia.taylor@slalom.com"]
     },
     "Digital Strategy": {
         "description": "Digital transformation planning and strategic technology roadmaps",
@@ -55,7 +59,7 @@ capabilities = {
         "certifications": ["Digital Transformation Certificate", "Agile Certified Practitioner"],
         "industry_verticals": ["Healthcare", "Financial Services", "Government"],
         "capacity": 25,
-        "consultants": ["liam.anderson@slalom.com", "noah.martinez@slalom.com"]
+        "consultant_emails": ["liam.anderson@slalom.com", "noah.martinez@slalom.com"]
     },
     "Change Management": {
         "description": "Organizational change leadership and adoption strategies",
@@ -64,7 +68,7 @@ capabilities = {
         "certifications": ["Prosci Certified", "Lean Six Sigma Black Belt"],
         "industry_verticals": ["Healthcare", "Manufacturing", "Government"],
         "capacity": 20,
-        "consultants": ["ava.garcia@slalom.com", "mia.rodriguez@slalom.com"]
+        "consultant_emails": ["ava.garcia@slalom.com", "mia.rodriguez@slalom.com"]
     },
     "UX/UI Design": {
         "description": "User experience design and digital product innovation",
@@ -73,7 +77,7 @@ capabilities = {
         "certifications": ["Adobe Certified Expert", "Google UX Design Certificate"],
         "industry_verticals": ["Retail", "Healthcare", "Technology"],
         "capacity": 30,
-        "consultants": ["amelia.lee@slalom.com", "harper.white@slalom.com"]
+        "consultant_emails": ["amelia.lee@slalom.com", "harper.white@slalom.com"]
     },
     "Cybersecurity": {
         "description": "Information security strategy, risk assessment, and compliance",
@@ -82,7 +86,7 @@ capabilities = {
         "certifications": ["CISSP", "CISM", "CompTIA Security+"],
         "industry_verticals": ["Financial Services", "Healthcare", "Government"],
         "capacity": 25,
-        "consultants": ["ella.clark@slalom.com", "scarlett.lewis@slalom.com"]
+        "consultant_emails": ["ella.clark@slalom.com", "scarlett.lewis@slalom.com"]
     },
     "Business Intelligence": {
         "description": "Enterprise reporting, data warehousing, and business analytics",
@@ -91,7 +95,7 @@ capabilities = {
         "certifications": ["Microsoft BI Certification", "Qlik Sense Certified"],
         "industry_verticals": ["Retail", "Manufacturing", "Financial Services"],
         "capacity": 35,
-        "consultants": ["james.walker@slalom.com", "benjamin.hall@slalom.com"]
+        "consultant_emails": ["james.walker@slalom.com", "benjamin.hall@slalom.com"]
     },
     "Agile Coaching": {
         "description": "Agile transformation and team coaching for scaled delivery",
@@ -100,9 +104,83 @@ capabilities = {
         "certifications": ["Certified Scrum Master", "SAFe Agilist", "ICAgile Certified"],
         "industry_verticals": ["Technology", "Financial Services", "Healthcare"],
         "capacity": 20,
-        "consultants": ["charlotte.young@slalom.com", "henry.king@slalom.com"]
+        "consultant_emails": ["charlotte.young@slalom.com", "henry.king@slalom.com"]
     }
 }
+
+
+class ConsultantBase(BaseModel):
+    name: str
+    email: EmailStr
+    practice_area: str
+    location: str
+    bio: str
+    contact_details: Optional[str] = None
+
+
+class ConsultantCreate(ConsultantBase):
+    pass
+
+
+class ConsultantUpdate(BaseModel):
+    name: Optional[str] = None
+    practice_area: Optional[str] = None
+    location: Optional[str] = None
+    bio: Optional[str] = None
+    contact_details: Optional[str] = None
+
+
+def build_profile(email: str, practice_area: str, location: str) -> Dict[str, Optional[str]]:
+    first_name, last_name = email.split("@")[0].split(".")
+    return {
+        "name": f"{first_name.title()} {last_name.title()}",
+        "email": email,
+        "practice_area": practice_area,
+        "location": location,
+        "bio": f"{first_name.title()} supports {practice_area.lower()} engagements across Slalom accounts.",
+        "contact_details": None,
+    }
+
+
+consultants = {
+    "alice.smith@slalom.com": build_profile("alice.smith@slalom.com", "Technology", "Seattle, WA"),
+    "bob.johnson@slalom.com": build_profile("bob.johnson@slalom.com", "Technology", "Chicago, IL"),
+    "emma.davis@slalom.com": build_profile("emma.davis@slalom.com", "Technology", "Atlanta, GA"),
+    "sophia.wilson@slalom.com": build_profile("sophia.wilson@slalom.com", "Technology", "Denver, CO"),
+    "john.brown@slalom.com": build_profile("john.brown@slalom.com", "Technology", "Austin, TX"),
+    "olivia.taylor@slalom.com": build_profile("olivia.taylor@slalom.com", "Technology", "Portland, OR"),
+    "liam.anderson@slalom.com": build_profile("liam.anderson@slalom.com", "Strategy", "Boston, MA"),
+    "noah.martinez@slalom.com": build_profile("noah.martinez@slalom.com", "Strategy", "New York, NY"),
+    "ava.garcia@slalom.com": build_profile("ava.garcia@slalom.com", "Operations", "Dallas, TX"),
+    "mia.rodriguez@slalom.com": build_profile("mia.rodriguez@slalom.com", "Operations", "Phoenix, AZ"),
+    "amelia.lee@slalom.com": build_profile("amelia.lee@slalom.com", "Technology", "Los Angeles, CA"),
+    "harper.white@slalom.com": build_profile("harper.white@slalom.com", "Technology", "San Francisco, CA"),
+    "ella.clark@slalom.com": build_profile("ella.clark@slalom.com", "Technology", "Washington, DC"),
+    "scarlett.lewis@slalom.com": build_profile("scarlett.lewis@slalom.com", "Technology", "Miami, FL"),
+    "james.walker@slalom.com": build_profile("james.walker@slalom.com", "Technology", "Detroit, MI"),
+    "benjamin.hall@slalom.com": build_profile("benjamin.hall@slalom.com", "Technology", "Minneapolis, MN"),
+    "charlotte.young@slalom.com": build_profile("charlotte.young@slalom.com", "Operations", "Nashville, TN"),
+    "henry.king@slalom.com": build_profile("henry.king@slalom.com", "Operations", "Columbus, OH"),
+}
+
+
+def consultant_payload(email: str) -> Dict[str, Optional[str]]:
+    consultant = consultants.get(email)
+    if consultant is None:
+        raise HTTPException(status_code=500, detail=f"Consultant record missing for {email}")
+    return deepcopy(consultant)
+
+
+def capability_payload(name: str, details: Dict[str, object]) -> Dict[str, object]:
+    payload = deepcopy(details)
+    consultant_emails: List[str] = payload.pop("consultant_emails", [])
+    payload["consultants"] = [consultant_payload(email) for email in consultant_emails]
+    return payload
+
+
+def ensure_consultant_exists(email: str) -> None:
+    if email not in consultants:
+        raise HTTPException(status_code=404, detail="Consultant not found")
 
 
 @app.get("/")
@@ -112,7 +190,44 @@ def root():
 
 @app.get("/capabilities")
 def get_capabilities():
-    return capabilities
+    return {
+        capability_name: capability_payload(capability_name, details)
+        for capability_name, details in capabilities.items()
+    }
+
+
+@app.get("/consultants")
+def get_consultants():
+    return sorted(
+        (deepcopy(consultant) for consultant in consultants.values()),
+        key=lambda consultant: consultant["name"],
+    )
+
+
+@app.get("/consultants/{email}")
+def get_consultant(email: EmailStr):
+    ensure_consultant_exists(str(email))
+    return consultant_payload(str(email))
+
+
+@app.post("/consultants", status_code=201)
+def create_consultant(consultant: ConsultantCreate):
+    email = str(consultant.email)
+    if email in consultants:
+        raise HTTPException(status_code=400, detail="Consultant already exists")
+
+    consultants[email] = consultant.model_dump()
+    return consultant_payload(email)
+
+
+@app.put("/consultants/{email}")
+def update_consultant(email: EmailStr, consultant_update: ConsultantUpdate):
+    email_str = str(email)
+    ensure_consultant_exists(email_str)
+
+    updates = consultant_update.model_dump(exclude_unset=True)
+    consultants[email_str].update(updates)
+    return consultant_payload(email_str)
 
 
 @app.post("/capabilities/{capability_name}/register")
@@ -122,19 +237,22 @@ def register_for_capability(capability_name: str, email: str):
     if capability_name not in capabilities:
         raise HTTPException(status_code=404, detail="Capability not found")
 
+    ensure_consultant_exists(email)
+
     # Get the specific capability
     capability = capabilities[capability_name]
 
     # Validate consultant is not already registered
-    if email in capability["consultants"]:
+    if email in capability["consultant_emails"]:
         raise HTTPException(
             status_code=400,
             detail="Consultant is already registered for this capability"
         )
 
     # Add consultant
-    capability["consultants"].append(email)
-    return {"message": f"Registered {email} for {capability_name}"}
+    capability["consultant_emails"].append(email)
+    consultant = consultant_payload(email)
+    return {"message": f"Registered {consultant['name']} for {capability_name}"}
 
 
 @app.delete("/capabilities/{capability_name}/unregister")
@@ -144,16 +262,19 @@ def unregister_from_capability(capability_name: str, email: str):
     if capability_name not in capabilities:
         raise HTTPException(status_code=404, detail="Capability not found")
 
+    ensure_consultant_exists(email)
+
     # Get the specific capability
     capability = capabilities[capability_name]
 
     # Validate consultant is registered
-    if email not in capability["consultants"]:
+    if email not in capability["consultant_emails"]:
         raise HTTPException(
             status_code=400,
             detail="Consultant is not registered for this capability"
         )
 
     # Remove consultant
-    capability["consultants"].remove(email)
-    return {"message": f"Unregistered {email} from {capability_name}"}
+    capability["consultant_emails"].remove(email)
+    consultant = consultant_payload(email)
+    return {"message": f"Unregistered {consultant['name']} from {capability_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -1,8 +1,87 @@
 document.addEventListener("DOMContentLoaded", () => {
   const capabilitiesList = document.getElementById("capabilities-list");
+  const consultantsList = document.getElementById("consultants-list");
   const capabilitySelect = document.getElementById("capability");
+  const consultantSelect = document.getElementById("consultant-registration");
   const registerForm = document.getElementById("register-form");
+  const consultantForm = document.getElementById("consultant-form");
+  const consultantSubmit = document.getElementById("consultant-submit");
+  const consultantCancel = document.getElementById("consultant-cancel");
   const messageDiv = document.getElementById("message");
+  let consultantInEdit = null;
+
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function resetConsultantForm() {
+    consultantForm.reset();
+    consultantInEdit = null;
+    document.getElementById("consultant-email").disabled = false;
+    consultantSubmit.textContent = "Create Consultant";
+    consultantCancel.classList.add("hidden");
+  }
+
+  function populateConsultantForm(consultant) {
+    consultantInEdit = consultant.email;
+    document.getElementById("consultant-name").value = consultant.name;
+    document.getElementById("consultant-email").value = consultant.email;
+    document.getElementById("consultant-email").disabled = true;
+    document.getElementById("consultant-practice-area").value = consultant.practice_area;
+    document.getElementById("consultant-location").value = consultant.location;
+    document.getElementById("consultant-bio").value = consultant.bio;
+    document.getElementById("consultant-contact-details").value = consultant.contact_details || "";
+    consultantSubmit.textContent = "Update Consultant";
+    consultantCancel.classList.remove("hidden");
+  }
+
+  function renderConsultants(consultants) {
+    consultantsList.innerHTML = "";
+    consultantSelect.innerHTML = '<option value="">-- Select a consultant --</option>';
+
+    if (consultants.length === 0) {
+      consultantsList.innerHTML = "<p><em>No consultants created yet</em></p>";
+      return;
+    }
+
+    consultants.forEach((consultant) => {
+      const card = document.createElement("div");
+      card.className = "consultant-card";
+      card.innerHTML = `
+        <div class="consultant-card-header">
+          <div>
+            <h4>${consultant.name}</h4>
+            <p class="consultant-meta">${consultant.practice_area} • ${consultant.location}</p>
+          </div>
+          <button type="button" class="edit-btn" data-email="${consultant.email}">Edit</button>
+        </div>
+        <p class="consultant-email-line">${consultant.email}</p>
+        <p>${consultant.bio}</p>
+        <p><strong>Contact:</strong> ${consultant.contact_details || "Not provided"}</p>
+      `;
+      consultantsList.appendChild(card);
+
+      const option = document.createElement("option");
+      option.value = consultant.email;
+      option.textContent = `${consultant.name} (${consultant.email})`;
+      consultantSelect.appendChild(option);
+    });
+
+    document.querySelectorAll(".edit-btn").forEach((button) => {
+      button.addEventListener("click", async () => {
+        const email = button.getAttribute("data-email");
+        const response = await fetch(`/consultants/${encodeURIComponent(email)}`);
+        const consultant = await response.json();
+        populateConsultantForm(consultant);
+      });
+    });
+  }
 
   // Function to fetch capabilities from API
   async function fetchCapabilities() {
@@ -12,6 +91,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       capabilitiesList.innerHTML = "";
+      capabilitySelect.innerHTML = '<option value="">-- Select a capability --</option>';
 
       // Populate capabilities list
       Object.entries(capabilities).forEach(([name, details]) => {
@@ -29,8 +109,14 @@ document.addEventListener("DOMContentLoaded", () => {
               <ul class="consultants-list">
                 ${details.consultants
                   .map(
-                    (email) =>
-                      `<li><span class="consultant-email">${email}</span><button class="delete-btn" data-capability="${name}" data-email="${email}">❌</button></li>`
+                    (consultant) =>
+                      `<li>
+                        <div class="consultant-summary">
+                          <span class="consultant-email">${consultant.name}</span>
+                          <span class="consultant-subtitle">${consultant.email} • ${consultant.practice_area}</span>
+                        </div>
+                        <button class="delete-btn" data-capability="${name}" data-email="${consultant.email}">Remove</button>
+                      </li>`
                   )
                   .join("")}
               </ul>
@@ -69,6 +155,18 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   }
 
+  async function fetchConsultants() {
+    try {
+      const response = await fetch("/consultants");
+      const consultants = await response.json();
+      renderConsultants(consultants);
+    } catch (error) {
+      consultantsList.innerHTML =
+        "<p>Failed to load consultants. Please try again later.</p>";
+      console.error("Error fetching consultants:", error);
+    }
+  }
+
   // Handle unregister functionality
   async function handleUnregister(event) {
     const button = event.target;
@@ -88,35 +186,84 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
 
         // Refresh capabilities list to show updated consultants
         fetchCapabilities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
+
+  consultantForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const consultantPayload = {
+      name: document.getElementById("consultant-name").value,
+      email: document.getElementById("consultant-email").value,
+      practice_area: document.getElementById("consultant-practice-area").value,
+      location: document.getElementById("consultant-location").value,
+      bio: document.getElementById("consultant-bio").value,
+      contact_details: document.getElementById("consultant-contact-details").value || null,
+    };
+
+    const isEdit = Boolean(consultantInEdit);
+    const endpoint = isEdit
+      ? `/consultants/${encodeURIComponent(consultantInEdit)}`
+      : "/consultants";
+    const method = isEdit ? "PUT" : "POST";
+    const body = isEdit
+      ? JSON.stringify({
+          name: consultantPayload.name,
+          practice_area: consultantPayload.practice_area,
+          location: consultantPayload.location,
+          bio: consultantPayload.bio,
+          contact_details: consultantPayload.contact_details,
+        })
+      : JSON.stringify(consultantPayload);
+
+    try {
+      const response = await fetch(endpoint, {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body,
+      });
+      const result = await response.json();
+
+      if (!response.ok) {
+        showMessage(result.detail || "Failed to save consultant.", "error");
+        return;
+      }
+
+      resetConsultantForm();
+      fetchConsultants();
+      showMessage(
+        isEdit
+          ? `Updated consultant profile for ${result.name}.`
+          : `Created consultant profile for ${result.name}.`,
+        "success"
+      );
+    } catch (error) {
+      showMessage("Failed to save consultant. Please try again.", "error");
+      console.error("Error saving consultant:", error);
+    }
+  });
+
+  consultantCancel.addEventListener("click", () => {
+    resetConsultantForm();
+  });
 
   // Handle form submission
   registerForm.addEventListener("submit", async (event) => {
     event.preventDefault();
 
-    const email = document.getElementById("email").value;
+    const email = consultantSelect.value;
     const capability = document.getElementById("capability").value;
 
     try {
@@ -132,31 +279,22 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         registerForm.reset();
 
         // Refresh capabilities list to show updated consultants
         fetchCapabilities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to register. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to register. Please try again.", "error");
       console.error("Error registering:", error);
     }
   });
 
   // Initialize app
   fetchCapabilities();
+  fetchConsultants();
+  resetConsultantForm();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -26,12 +26,60 @@
         </div>
       </section>
 
+      <section id="consultants-container">
+        <h3>Consultant Directory</h3>
+        <div id="consultants-list">
+          <p>Loading consultants...</p>
+        </div>
+      </section>
+
+      <section id="profile-container">
+        <h3>Consultant Profile</h3>
+        <form id="consultant-form">
+          <div class="form-group">
+            <label for="consultant-name">Name:</label>
+            <input type="text" id="consultant-name" required placeholder="Alex Morgan" />
+          </div>
+          <div class="form-group">
+            <label for="consultant-email">Email:</label>
+            <input type="email" id="consultant-email" required placeholder="alex.morgan@slalom.com" />
+          </div>
+          <div class="form-group">
+            <label for="consultant-practice-area">Practice Area:</label>
+            <select id="consultant-practice-area" required>
+              <option value="">-- Select a practice area --</option>
+              <option value="Strategy">Strategy</option>
+              <option value="Technology">Technology</option>
+              <option value="Operations">Operations</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label for="consultant-location">Location:</label>
+            <input type="text" id="consultant-location" required placeholder="Seattle, WA" />
+          </div>
+          <div class="form-group">
+            <label for="consultant-bio">Bio / Summary:</label>
+            <textarea id="consultant-bio" rows="4" required placeholder="Brief consulting profile summary"></textarea>
+          </div>
+          <div class="form-group">
+            <label for="consultant-contact-details">Optional Contact Details:</label>
+            <input type="text" id="consultant-contact-details" placeholder="Slack, phone, or staffing notes" />
+          </div>
+          <div class="form-actions">
+            <button type="submit" id="consultant-submit">Create Consultant</button>
+            <button type="button" id="consultant-cancel" class="secondary hidden">Cancel Edit</button>
+          </div>
+        </form>
+      </section>
+
       <section id="register-container">
         <h3>Register Your Expertise</h3>
         <form id="register-form">
           <div class="form-group">
-            <label for="email">Consultant Email:</label>
-            <input type="email" id="email" required placeholder="your-email@slalom.com" />
+            <label for="consultant-registration">Consultant:</label>
+            <select id="consultant-registration" required>
+              <option value="">-- Select a consultant --</option>
+            </select>
           </div>
           <div class="form-group">
             <label for="capability">Select Capability:</label>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -9,7 +9,7 @@ body {
   font-family: Arial, sans-serif;
   line-height: 1.6;
   color: #333;
-  max-width: 1200px;
+  max-width: 1400px;
   margin: 0 auto;
   padding: 20px;
   background-color: #f5f5f5;
@@ -52,15 +52,15 @@ header {
 }
 
 main {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 30px;
-  justify-content: center;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: start;
 }
 
 @media (min-width: 768px) {
   main {
-    grid-template-columns: 2fr 1fr;
+    grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr) minmax(0, 1fr);
   }
 }
 
@@ -70,7 +70,7 @@ section {
   border-radius: 5px;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
   width: 100%;
-  max-width: 500px;
+  max-width: none;
 }
 
 section h3 {
@@ -129,22 +129,33 @@ section h3 {
 }
 
 .consultants-section ul li {
-  padding: 6px 0;
   position: relative;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   background: rgba(0, 102, 204, 0.05);
   margin-bottom: 4px;
   padding: 8px 12px;
   border-radius: 6px;
+  gap: 12px;
 }
 
 .consultant-email {
+  display: block;
   flex-grow: 1;
   margin-right: 8px;
   font-weight: 500;
   color: #003d7a;
+}
+
+.consultant-summary {
+  display: flex;
+  flex-direction: column;
+}
+
+.consultant-subtitle {
+  color: #5b6b7f;
+  font-size: 0.92rem;
 }
 
 .delete-btn {
@@ -153,7 +164,7 @@ section h3 {
   color: white;
   cursor: pointer;
   font-size: 12px;
-  padding: 4px 8px;
+  padding: 6px 10px;
   transition: all 0.2s;
   border-radius: 4px;
   font-weight: bold;
@@ -184,12 +195,23 @@ section h3 {
 }
 
 .form-group input,
-.form-group select {
+.form-group select,
+.form-group textarea {
   width: 100%;
   padding: 10px;
   border: 1px solid #ddd;
   border-radius: 4px;
   font-size: 16px;
+}
+
+.form-group textarea {
+  resize: vertical;
+}
+
+.form-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
 button[type="submit"] {
@@ -210,6 +232,64 @@ button[type="submit"]:hover {
   background: linear-gradient(135deg, #0066cc, #1976d2);
   transform: translateY(-2px);
   box-shadow: 0 4px 8px rgba(0, 61, 122, 0.3);
+}
+
+.secondary {
+  background: white;
+  color: #003d7a;
+  border: 1px solid #003d7a;
+  padding: 12px 20px;
+  font-size: 16px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.secondary:hover {
+  background: #eef5ff;
+}
+
+.consultant-card {
+  border: 1px solid #d7e4f5;
+  border-radius: 10px;
+  padding: 16px;
+  background: linear-gradient(180deg, #ffffff, #f8fbff);
+  margin-bottom: 14px;
+}
+
+.consultant-card h4 {
+  color: #003d7a;
+}
+
+.consultant-card-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+  margin-bottom: 8px;
+}
+
+.consultant-meta,
+.consultant-email-line {
+  color: #5b6b7f;
+}
+
+.consultant-email-line {
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.edit-btn {
+  background: #e8f1fb;
+  color: #003d7a;
+  border: 1px solid #b5cce8;
+  border-radius: 6px;
+  padding: 6px 12px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.edit-btn:hover {
+  background: #d8e8fb;
 }
 
 .message {
@@ -287,6 +367,10 @@ footer {
 
 /* Responsive design improvements */
 @media (max-width: 768px) {
+  main {
+    grid-template-columns: 1fr;
+  }
+
   .header-content {
     flex-direction: column;
     gap: 10px;
@@ -303,5 +387,11 @@ footer {
   
   .header-text h2 {
     font-size: 1rem;
+  }
+
+  .consultant-card-header,
+  .consultants-section ul li,
+  .form-actions {
+    flex-direction: column;
   }
 }


### PR DESCRIPTION
## Summary
- add first-class consultant profile records and CRUD API endpoints
- update capability responses and registration flows to use consultant records instead of raw email-only input
- add a consultant directory and profile create/edit experience to the dashboard

## Verification
- ran the FastAPI app locally and exercised consultant list, create, update, and capability registration over HTTP

Closes #5